### PR TITLE
V3.3.12 Set Env BLUENOTEBOOK_LOCALE correctly

### DIFF
--- a/bluenotebook/main.py
+++ b/bluenotebook/main.py
@@ -88,7 +88,7 @@ def main():
 
     try:
         # Définir les informations de l'application
-        version = "3.3.11"
+        version = "3.3.12"
         app.setApplicationName("BlueNotebook")
         app.setApplicationVersion(version)
         app.setOrganizationName("BlueNotebook")

--- a/bluenotebook/resources/html/aide_en_ligne.html
+++ b/bluenotebook/resources/html/aide_en_ligne.html
@@ -107,7 +107,7 @@
     <header>
         <h1>
             <img src="../images/bluenotebook_256-x256_fond_blanc.png" alt="Icône BlueNotebook" class="header-icon">
-            Aide en Ligne - BlueNotebook V3.3.11</h1>
+            Aide en Ligne - BlueNotebook <V3 class="3 12"></V3></h1>
     </header>
 
 <div class="main-container">
@@ -1142,7 +1142,7 @@ Aide
 
     <footer>
         <hr>
-        <p><em>Ce manuel a été rédigé pour la version V3.3.11 de BlueNotebook.</em></p>
+        <p><em>Ce manuel a été rédigé pour la version V3.3.12 de BlueNotebook.</em></p>
         <p>Si vous rencontrez des erreurs ou dysfonctionnements, vous pouvez notifier ceux-ci sur le <a href="https://github.com/lephotographelibre/BlueNotebook/issues">site du développeur</a>.</p>
         <p>BlueNotebook est un logiciel libre distribué sous les termes de la <a href="https://www.gnu.org/licenses/gpl-3.0.html">Licence Publique Générale GNU v3</a>.</p>
     </footer>

--- a/bluenotebook/run_bluenotebook.sh
+++ b/bluenotebook/run_bluenotebook.sh
@@ -83,7 +83,10 @@ fi
 echo "" # Ligne vide pour l'aération
 echo "📘 Lancement de l'application BlueNotebook..."
 
+# locale -c  
 # export BLUENOTEBOOK_LOCALE=de_DE
+export BLUENOTEBOOK_LOCALE="fr_FR.utf8"
+
 # Définir la locale pour l'application, avec 'fr_FR' comme valeur par défaut
 export BLUENOTEBOOK_LOCALE="${BLUENOTEBOOK_LOCALE:-fr_FR}"
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,15 @@
+## V3.3.12 Set Env BLUENOTEBOOK_LOCALE correctly
+
+Pour eviter l'erreur au demarrage 
+
+⚠️ Impossible de configurer la locale Python pour 'fr_FR'. Utilisation de la locale système par défaut.
+vérifier les locales disponibles sur votre machine. Ouvrez un terminal et tapez la commande suivante : $locale -c  --> fr_FR.utf8 
+
+# locale -c  
+# export BLUENOTEBOOK_LOCALE=de_DE
+# export BLUENOTEBOOK_LOCALE=fr_FR -- Ancienne valeur généranr l'erreur
+export BLUENOTEBOOK_LOCALE="fr_FR.utf8"
+
 ## V3.3.11 Fix Issue [#66] Notes: After pressing CTRL-M, the file browser displays a list that is too small. #66
 
 Fix Issue [#66](https://github.com/lephotographelibre/BlueNotebook/issues/66)  Notes: After pressing CTRL-M, the file browser displays a list that is too small. #66


### PR DESCRIPTION
set locale correctly on Linux 
export BLUENOTEBOOK_LOCALE="fr_FR.utf8"