### PR TITLE
V4.1.3 fix flatpak linter errors

### DIFF
--- a/bluenotebook/main.py
+++ b/bluenotebook/main.py
@@ -132,7 +132,7 @@ def main():
     args = parser.parse_args()
 
     try:
-        version = "4.1.2"
+        version = "4.1.3"
         app.setApplicationName("BlueNotebook")
         app.setApplicationVersion(version)
         app.setOrganizationName("BlueNotebook")

--- a/bluenotebook/resources/html/aide_en_ligne.html
+++ b/bluenotebook/resources/html/aide_en_ligne.html
@@ -107,7 +107,7 @@
     <header>
         <h1>
             <img src="../images/bluenotebook_256-x256_fond_blanc.png" alt="Icône BlueNotebook" class="header-icon">
-            Aide en Ligne - BlueNotebook V4.1.2</h1>
+            Aide en Ligne - BlueNotebook V4.1.3</h1>
     </header>
 
 <div class="main-container">
@@ -1184,7 +1184,7 @@ Aide
 
     <footer>
         <hr>
-        <p><em>Ce manuel a été rédigé pour la version V4.1.2 de BlueNotebook.</em></p>
+        <p><em>Ce manuel a été rédigé pour la version V4.1.3 de BlueNotebook.</em></p>
 
         <p>Si vous rencontrez des erreurs ou dysfonctionnements, vous pouvez notifier ceux-ci sur le <a href="https://github.com/lephotographelibre/BlueNotebook/issues">site du développeur</a>.</p>
         <p>BlueNotebook est un logiciel libre distribué sous les termes de la <a href="https://www.gnu.org/licenses/gpl-3.0.html">Licence Publique Générale GNU v3</a>.</p>

--- a/bluenotebook/resources/html/aide_en_ligne.md
+++ b/bluenotebook/resources/html/aide_en_ligne.md
@@ -1,4 +1,4 @@
-#  Aide en Ligne - BlueNotebook V4.1.2
+#  Aide en Ligne - BlueNotebook V4.1.3
 
 ## Table des matières
 *   [1. Introduction](#introduction)
@@ -865,7 +865,7 @@ Vous trouverez ici les réponses aux questions les plus fréquentes sur l'utilis
     *   **Dépôt GitHub :** <a href="https://github.com/geopy/geopy" target="_blank">github.com/geopy/geopy</a>
 
 ---
-*Ce manuel a été rédigé pour la version V4.1.2 de BlueNotebook.*
+*Ce manuel a été rédigé pour la version V4.1.3 de BlueNotebook.*
 
 Si vous rencontrez des erreurs ou dysfonctionnements, vous pouvez notifier ceux-ci sur le <a href="https://github.com/lephotographelibre/BlueNotebook/issues">site du développeur</a>.
 

--- a/bluenotebook/resources/html/online_help.html
+++ b/bluenotebook/resources/html/online_help.html
@@ -107,7 +107,7 @@
     <header>
         <h1>
             <img src="../images/bluenotebook_256-x256_fond_blanc.png" alt="BlueNotebook Icon" class="header-icon">
-            Online Help - BlueNotebook V4.1.2</h1>
+            Online Help - BlueNotebook V4.1.3</h1>
     </header>
 
 <div class="main-container">
@@ -1178,7 +1178,7 @@ Help
 
     <footer>
         <hr>
-        <p><em>This manual was written for BlueNotebook V4.1.2 </em></p>
+        <p><em>This manual was written for BlueNotebook V4.1.3 </em></p>
         <p>If you encounter errors or malfunctions, you can notify them on the <a href="https://github.com/lephotographelibre/BlueNotebook/issues">developer's site</a>.</p>
         <p>BlueNotebook is free software distributed under the terms of the <a href="https://www.gnu.org/licenses/gpl-3.0.html">GNU General Public License v3</a>.</p>
     </footer>

--- a/bluenotebook/resources/html/online_help.md
+++ b/bluenotebook/resources/html/online_help.md
@@ -1,4 +1,4 @@
-# Online Help - BlueNotebook V4.1.2
+# Online Help - BlueNotebook V4.1.3
 
 ## Table of Contents
 *   [1. Introduction](#introduction)
@@ -869,7 +869,7 @@ Here is a list of the main Python libraries that power the BlueNotebook project,
     *   **GitHub Repository:** [github.com/geopy/geopy](https://github.com/geopy/geopy)
 
 ---
-*This manual was written for BlueNotebook V4.1.2*
+*This manual was written for BlueNotebook V4.1.3*
 
 If you encounter errors or malfunctions, you can notify them on the [developer's site](https://github.com/lephotographelibre/BlueNotebook/issues).
 

--- a/flatpak/io.github.lephotographelibre.BlueNotebook.metainfo.xml
+++ b/flatpak/io.github.lephotographelibre.BlueNotebook.metainfo.xml
@@ -4,9 +4,7 @@
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-3.0-or-later</project_license>
   <name>BlueNotebook</name>
-  <developer id="io.github.lephotographelibre">
-    <name>Jean-Marc DIGNE</name>
-  </developer>
+  <developer_name>Jean-Marc DIGNE</developer_name>
   <branding>
     <color type="primary" scheme_preference="light">#e6eaea</color>
     <color type="primary" scheme_preference="dark">#0e6fb3</color>
@@ -79,6 +77,6 @@
   <url type="bugtracker">https://github.com/lephotographelibre/BlueNotebook/issues</url>
   <content_rating type="oars-1.1" />
   <releases>
-    <release version="4.1.2" date="2025-12-26" />
+    <release version="4.1.3" date="2025-12-26" />
   </releases>
 </component>

--- a/flatpak/io.github.lephotographelibre.BlueNotebook.yaml
+++ b/flatpak/io.github.lephotographelibre.BlueNotebook.yaml
@@ -22,7 +22,7 @@ finish-args:
     # --filesystem=xdg-documents
   - --filesystem=home
   # Accès au fichier de configuration sur l'hôte (au lieu du dossier privé de la sandbox)
-  - --filesystem=xdg-config/BlueNotebook
+  #- --filesystem=xdg-config/BlueNotebook
   # Accès au portail du bureau pour une meilleure intégration (ouverture de liens)
   #- --talk-name=org.freedesktop.portal.Desktop
   # Permet de lire la liste des applications par défaut pour éviter le sélecteur
@@ -111,4 +111,4 @@ modules:
     sources:
       - type: git
         url: https://github.com/lephotographelibre/BlueNotebook.git
-        tag: v4.1.2
+        tag: v4.1.3


### PR DESCRIPTION

1. erreur linter         "appstream-missing-developer-name",
```xml
  <developer id="io.github.lephotographelibre">
    <name>Jean-Marc DIGNE</name>
  </developer>

   <developer_name>Jean-Marc DIGNE</developer_name>
```

2. Erreur Linter         "finish-args-unnecessary-xdg-config-BlueNotebook-rw-access",

  # Accès au fichier de configuration sur l'hôte (au lieu du dossier privé de la sandbox)
  #- --filesystem=xdg-config/BlueNotebook
